### PR TITLE
Pin setuptools<81 so pkg_resources still exists at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN export BUILD_DEPS="libopenblas-dev liblapack-dev libmpfr-dev libmpc-dev libg
     rm -rf /var/lib/apt/lists/*
 COPY . .
 RUN apt-get update && apt-get -y install gcc && \
-    pip install setuptools && \
+    pip install "setuptools<81" && \
     python3 setup.py build_ext --inplace && \
     apt-get purge -y --auto-remove gcc && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
python-graph-core 1.8.2 calls pkg_resources.declare_namespace() when it is imported. setuptools 81 deprecated pkg_resources and 83 removed it, so an unpinned `pip install setuptools` now produces an image that builds cleanly and then dies on startup:

    File "mlat/clocktrack.pyx", line 46, in init mlat.clocktrack
      import pygraph.classes.graph
    ModuleNotFoundError: No module named 'pkg_resources'

setuptools' own deprecation notice recommends exactly this pin.